### PR TITLE
Enable plugins on lookahead

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ export default function(acorn) {
   }
 
   function parseTopLevel(node) {
-    const lookahead = acorn.tokenizer(this.input);
+    const lookahead = acorn.tokenizer(this.input, { plugins: acorn.plugins });
     let token = lookahead.getToken();
     let body = null;
     let id = null;


### PR DESCRIPTION
We run a lookahead pass for our syntax features, but we weren't
enabling any plugins for it. This change enables all available plugins
for lookahead parsing, which means that we can enable syntax extensions
in acorn.