### PR TITLE
Add peep ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,10 @@ Returns a [cell](#cell).
 
 Returns a [program](#program).
 
+<a href="#peekId" name="peekId">#</a> <b>peekId</b>(<i>input</i>) [<>](https://github.com/observablehq/parser/blob/master/src/parse.js "Source")
+
+Tries to find the ID of a cell given a snippet of its contents, and returns it as a string if found.
+
 ### Cell
 
 <a href="#cell_id" name="cell_id">#</a> <i>cell</i>.<b>id</b>

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-export {parseCell, CellParser, parseModule, ModuleParser} from "./parse.js";
+export {parseCell, peepId, CellParser, parseModule, ModuleParser} from "./parse.js";
 export {default as walk} from "./walk.js";

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-export {parseCell, peepId, CellParser, parseModule, ModuleParser} from "./parse.js";
+export {parseCell, peekId, CellParser, parseModule, ModuleParser} from "./parse.js";
 export {default as walk} from "./walk.js";

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,4 +1,4 @@
-import {getLineInfo, tokTypes as tt, Parser} from "acorn";
+import { getLineInfo, tokTypes as tt, Parser } from "acorn";
 import bigInt from "acorn-bigint";
 import dynamicImport from "./dynamic-import.js";
 import defaultGlobals from "./globals.js";
@@ -13,7 +13,7 @@ const STATE_MODIFIER = Symbol("modifier");
 const STATE_FUNCTION = Symbol("function");
 const STATE_NAME = Symbol("name");
 
-export function parseCell(input, {globals} = {}) {
+export function parseCell(input, { globals } = {}) {
   return parseReferences(CellParser.parse(input), input, globals);
 }
 
@@ -41,7 +41,7 @@ viewof|mutable|async      │                ▼
               └────────┘
 */
 
-export function peepId(input) {
+export function peekId(input) {
   let state = STATE_START;
   let name;
   try {
@@ -52,11 +52,9 @@ export function peepId(input) {
           if (token.type === tt.name) {
             if (
               state === STATE_START &&
-              (
-                token.value === "viewof" ||
+              (token.value === "viewof" ||
                 token.value === "mutable" ||
-                token.value === "async"
-              )
+                token.value === "async")
             ) {
               state = STATE_MODIFIER;
               continue;
@@ -77,7 +75,8 @@ export function peepId(input) {
         }
         case STATE_FUNCTION: {
           if (token.type === tt.star) continue;
-          if (token.type === tt.name && token.end < input.length) return token.value;
+          if (token.type === tt.name && token.end < input.length)
+            return token.value;
           break;
         }
       }
@@ -117,7 +116,8 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
       node.injections = this.parseImportSpecifiers();
     }
     this.expectContextual("from");
-    node.source = this.type === tt.string ? this.parseExprAtom() : this.unexpected();
+    node.source =
+      this.type === tt.string ? this.parseExprAtom() : this.unexpected();
     return this.finishNode(node, "ImportDeclaration");
   }
   parseImportSpecifiers() {
@@ -147,9 +147,11 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
     return nodes;
   }
   parseExprAtom() {
-    return this.parseMaybeKeywordExpression("viewof", "ViewExpression")
-        || this.parseMaybeKeywordExpression("mutable", "MutableExpression")
-        || super.parseExprAtom();
+    return (
+      this.parseMaybeKeywordExpression("viewof", "ViewExpression") ||
+      this.parseMaybeKeywordExpression("mutable", "MutableExpression") ||
+      super.parseExprAtom()
+    );
   }
   parseCell(node, eof) {
     const lookahead = new CellParser({}, this.input, this.start);
@@ -180,9 +182,10 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
         }
         token = lookahead.getToken();
         if (token.type === tt.eq) {
-          id = this.parseMaybeKeywordExpression("viewof", "ViewExpression")
-              || this.parseMaybeKeywordExpression("mutable", "MutableExpression")
-              || this.parseIdent();
+          id =
+            this.parseMaybeKeywordExpression("viewof", "ViewExpression") ||
+            this.parseMaybeKeywordExpression("mutable", "MutableExpression") ||
+            this.parseIdent();
           token = lookahead.getToken();
           this.expect(tt.eq);
         }
@@ -197,7 +200,11 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
       // Possibly a function or class declaration?
       else {
         body = this.parseExpression();
-        if (id === null && (body.type === "FunctionExpression" || body.type === "ClassExpression")) {
+        if (
+          id === null &&
+          (body.type === "FunctionExpression" ||
+            body.type === "ClassExpression")
+        ) {
           id = body.id;
         }
       }
@@ -217,7 +224,9 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
     return this.parseCell(node, true);
   }
   toAssignable(node, binding, errors) {
-    return node.type === "MutableExpression" ? node : super.toAssignable(node, binding, errors);
+    return node.type === "MutableExpression"
+      ? node
+      : super.toAssignable(node, binding, errors);
   }
   checkUnreserved(node) {
     if (node.name === "viewof" || node.name === "mutable") {
@@ -226,10 +235,17 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
     return super.checkUnreserved(node);
   }
   checkLVal(expr, bindingType, checkClashes) {
-    return super.checkLVal(expr.type === "MutableExpression" ? expr.id : expr, bindingType, checkClashes);
+    return super.checkLVal(
+      expr.type === "MutableExpression" ? expr.id : expr,
+      bindingType,
+      checkClashes
+    );
   }
   unexpected(pos) {
-    this.raise(pos != null ? pos : this.start, this.type === tt.eof ? "Unexpected end of input" : "Unexpected token");
+    this.raise(
+      pos != null ? pos : this.start,
+      this.type === tt.eof ? "Unexpected end of input" : "Unexpected token"
+    );
   }
   parseMaybeKeywordExpression(keyword, type) {
     if (this.isContextual(keyword)) {
@@ -241,7 +257,7 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
   }
 }
 
-export function parseModule(input, {globals} = {}) {
+export function parseModule(input, { globals } = {}) {
   const program = ModuleParser.parse(input);
   for (const cell of program.cells) {
     parseReferences(cell, input, globals);

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,4 +1,4 @@
-import { getLineInfo, tokTypes as tt, Parser } from "acorn";
+import {getLineInfo, tokTypes as tt, Parser} from "acorn";
 import bigInt from "acorn-bigint";
 import dynamicImport from "./dynamic-import.js";
 import defaultGlobals from "./globals.js";
@@ -8,7 +8,7 @@ const SCOPE_FUNCTION = 2;
 const SCOPE_ASYNC = 4;
 const SCOPE_GENERATOR = 8;
 
-export function parseCell(input, { globals } = {}) {
+export function parseCell(input, {globals} = {}) {
   return parseReferences(CellParser.parse(input), input, globals);
 }
 
@@ -83,8 +83,7 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
       node.injections = this.parseImportSpecifiers();
     }
     this.expectContextual("from");
-    node.source =
-      this.type === tt.string ? this.parseExprAtom() : this.unexpected();
+    node.source = this.type === tt.string ? this.parseExprAtom() : this.unexpected();
     return this.finishNode(node, "ImportDeclaration");
   }
   parseImportSpecifiers() {
@@ -114,11 +113,9 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
     return nodes;
   }
   parseExprAtom() {
-    return (
-      this.parseMaybeKeywordExpression("viewof", "ViewExpression") ||
-      this.parseMaybeKeywordExpression("mutable", "MutableExpression") ||
-      super.parseExprAtom()
-    );
+    return this.parseMaybeKeywordExpression("viewof", "ViewExpression")
+        || this.parseMaybeKeywordExpression("mutable", "MutableExpression")
+        || super.parseExprAtom();
   }
   parseCell(node, eof) {
     const lookahead = new CellParser({}, this.input, this.start);
@@ -149,10 +146,9 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
         }
         token = lookahead.getToken();
         if (token.type === tt.eq) {
-          id =
-            this.parseMaybeKeywordExpression("viewof", "ViewExpression") ||
-            this.parseMaybeKeywordExpression("mutable", "MutableExpression") ||
-            this.parseIdent();
+          id = this.parseMaybeKeywordExpression("viewof", "ViewExpression")
+              || this.parseMaybeKeywordExpression("mutable", "MutableExpression")
+              || this.parseIdent();
           token = lookahead.getToken();
           this.expect(tt.eq);
         }
@@ -167,11 +163,7 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
       // Possibly a function or class declaration?
       else {
         body = this.parseExpression();
-        if (
-          id === null &&
-          (body.type === "FunctionExpression" ||
-            body.type === "ClassExpression")
-        ) {
+        if (id === null && (body.type === "FunctionExpression" || body.type === "ClassExpression")) {
           id = body.id;
         }
       }
@@ -191,9 +183,7 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
     return this.parseCell(node, true);
   }
   toAssignable(node, binding, errors) {
-    return node.type === "MutableExpression"
-      ? node
-      : super.toAssignable(node, binding, errors);
+    return node.type === "MutableExpression" ? node : super.toAssignable(node, binding, errors);
   }
   checkUnreserved(node) {
     if (node.name === "viewof" || node.name === "mutable") {
@@ -202,17 +192,10 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
     return super.checkUnreserved(node);
   }
   checkLVal(expr, bindingType, checkClashes) {
-    return super.checkLVal(
-      expr.type === "MutableExpression" ? expr.id : expr,
-      bindingType,
-      checkClashes
-    );
+    return super.checkLVal(expr.type === "MutableExpression" ? expr.id : expr, bindingType, checkClashes);
   }
   unexpected(pos) {
-    this.raise(
-      pos != null ? pos : this.start,
-      this.type === tt.eof ? "Unexpected end of input" : "Unexpected token"
-    );
+    this.raise(pos != null ? pos : this.start, this.type === tt.eof ? "Unexpected end of input" : "Unexpected token");
   }
   parseMaybeKeywordExpression(keyword, type) {
     if (this.isContextual(keyword)) {
@@ -224,7 +207,7 @@ export class CellParser extends Parser.extend(bigInt, dynamicImport) {
   }
 }
 
-export function parseModule(input, { globals } = {}) {
+export function parseModule(input, {globals} = {}) {
   const program = ModuleParser.parse(input);
   for (const cell of program.cells) {
     parseReferences(cell, input, globals);

--- a/src/parse.js
+++ b/src/parse.js
@@ -13,14 +13,23 @@ export function parseCell(input, {globals} = {}) {
 }
 
 export function peepId(input) {
-  let tokens = Array.from(Parser.tokenizer(input));
+  let tokens;
+  try {
+    tokens = Array.from(Parser.tokenizer(input));
+  } catch (e) {
+    return;
+  }
 
   // Remove the * in generator functions
   tokens = tokens.filter(tok => tok.type.label !== "*");
 
+  if (!tokens.length) return;
+
   if (tokens[0].value === "viewof" || tokens[0].value === "mutable" || tokens[0].value === "async") {
     tokens.shift();
   }
+
+  if (tokens.length < 2) return;
 
   // a =
   if (tokens[0].type.label === "name" && tokens[1].type.label === "=") {

--- a/src/parse.js
+++ b/src/parse.js
@@ -48,7 +48,7 @@ export function peepId(input) {
     tokens[0].type.keyword === "function" ||
     tokens[0].type.keyword === "class"
   ) {
-    if (tokens[1].type.label === "name") {
+    if (tokens[1].type.label === "name" && tokens[1].end < input.length) {
       return tokens[1].value;
     }
   }

--- a/src/parse.js
+++ b/src/parse.js
@@ -12,6 +12,30 @@ export function parseCell(input, {globals} = {}) {
   return parseReferences(CellParser.parse(input), input, globals);
 }
 
+export function peepId(input) {
+  let tokens = Array.from(Parser.tokenizer(input));
+
+  // Remove the * in generator functions
+  tokens = tokens.filter(tok => tok.type.label !== "*");
+
+  if (tokens[0].value === "viewof" || tokens[0].value === "mutable" || tokens[0].value === "async") {
+    tokens.shift();
+  }
+
+  // a =
+  if (tokens[0].type.label === "name" && tokens[1].type.label === "=") {
+    return tokens[0].value;
+  }
+
+  // function a
+  // class A
+  if (tokens[0].type.keyword === "function" || tokens[0].type.keyword === "class") {
+    if (tokens[1].type.label === "name") {
+      return tokens[1].value;
+    }
+  }
+}
+
 export class CellParser extends Parser.extend(bigInt, dynamicImport) {
   enterScope(flags) {
     if (flags & SCOPE_FUNCTION) ++this.O_function;

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -1,8 +1,8 @@
-import { simple } from "acorn-walk";
+import {simple} from "acorn-walk";
 import tape from "tape-await";
-import { readdirSync, readFileSync, writeFileSync } from "fs";
-import { basename, extname, join } from "path";
-import { parseCell, peepId } from "../src/index.js";
+import {readdirSync, readFileSync, writeFileSync} from "fs";
+import {basename, extname, join} from "path";
+import {parseCell, peepId} from "../src/index.js";
 import walk from "../src/walk.js";
 
 tape("peepId", t => {
@@ -29,13 +29,11 @@ readdirSync(join("test", "input")).forEach(file => {
     let actual, expected;
 
     try {
-      actual = parseCell(readFileSync(infile, "utf8"), { globals: null });
+      actual = parseCell(readFileSync(infile, "utf8"), {globals: null});
     } catch (error) {
-      if (
-        error instanceof ReferenceError ||
-        error instanceof SyntaxError ||
-        error instanceof TypeError
-      ) {
+      if (error instanceof ReferenceError
+          || error instanceof SyntaxError
+          || error instanceof TypeError) {
         actual = {
           error: {
             type: error.constructor.name,
@@ -57,11 +55,7 @@ readdirSync(join("test", "input")).forEach(file => {
     } catch (error) {
       if (error.code === "ENOENT") {
         console.warn(`! generating ${outfile}`);
-        writeFileSync(
-          outfile,
-          JSON.stringify(actual, replacer, 2) + "\n",
-          "utf8"
-        );
+        writeFileSync(outfile, JSON.stringify(actual, replacer, 2) + "\n", "utf8");
         return;
       } else {
         throw error;

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -5,15 +5,21 @@ import {basename, extname, join} from "path";
 import {parseCell, peepId} from "../src/index.js";
 import walk from "../src/walk.js";
 
-tape("peepId", t => {
+tape.only("peepId", t => {
   t.equal(peepId("a = 1"), "a");
   t.equal(peepId("viewof a = 1"), "a");
   t.equal(peepId("mutable a = 1"), "a");
   t.equal(peepId("class A {"), "A");
-  t.equal(peepId("function a"), "a");
-  t.equal(peepId("async function a"), "a");
-  t.equal(peepId("function* a"), "a");
-  t.equal(peepId("function /* yeah */ a"), "a");
+  t.equal(peepId("class Z"), undefined);
+  t.equal(peepId("class Z "), "Z");
+  t.equal(peepId("function a"), undefined);
+  t.equal(peepId("function a()"), "a");
+  t.equal(peepId("async function a()"), "a");
+  t.equal(peepId("function* a"), undefined);
+  t.equal(peepId("function /* yeah */ a()"), "a");
+  t.equal(peepId("function"), undefined);
+  t.equal(peepId("1"), undefined);
+  t.equal(peepId("({ a: 1 })"), undefined);
   t.equal(
     peepId(`function queryAll(text, values) {
   return fetch("https://api.observable.localh`),

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -1,19 +1,24 @@
-import {simple} from "acorn-walk";
+import { simple } from "acorn-walk";
 import tape from "tape-await";
-import {readdirSync, readFileSync, writeFileSync} from "fs";
-import {basename, extname, join} from "path";
-import {parseCell, peepId} from "../src/index.js";
+import { readdirSync, readFileSync, writeFileSync } from "fs";
+import { basename, extname, join } from "path";
+import { parseCell, peepId } from "../src/index.js";
 import walk from "../src/walk.js";
 
-tape('peepId', t => {
-  t.equal(peepId('a = 1'), 'a');
-  t.equal(peepId('viewof a = 1'), 'a');
-  t.equal(peepId('mutable a = 1'), 'a');
-  t.equal(peepId('class A {'), 'A');
-  t.equal(peepId('function a'), 'a');
-  t.equal(peepId('async function a'), 'a');
-  t.equal(peepId('function* a'), 'a');
-  t.equal(peepId('function /* yeah */ a'), 'a');
+tape("peepId", t => {
+  t.equal(peepId("a = 1"), "a");
+  t.equal(peepId("viewof a = 1"), "a");
+  t.equal(peepId("mutable a = 1"), "a");
+  t.equal(peepId("class A {"), "A");
+  t.equal(peepId("function a"), "a");
+  t.equal(peepId("async function a"), "a");
+  t.equal(peepId("function* a"), "a");
+  t.equal(peepId("function /* yeah */ a"), "a");
+  t.equal(
+    peepId(`function queryAll(text, values) {
+  return fetch("https://api.observable.localh`),
+    "queryAll"
+  );
 });
 
 readdirSync(join("test", "input")).forEach(file => {
@@ -24,11 +29,13 @@ readdirSync(join("test", "input")).forEach(file => {
     let actual, expected;
 
     try {
-      actual = parseCell(readFileSync(infile, "utf8"), {globals: null});
+      actual = parseCell(readFileSync(infile, "utf8"), { globals: null });
     } catch (error) {
-      if (error instanceof ReferenceError
-          || error instanceof SyntaxError
-          || error instanceof TypeError) {
+      if (
+        error instanceof ReferenceError ||
+        error instanceof SyntaxError ||
+        error instanceof TypeError
+      ) {
         actual = {
           error: {
             type: error.constructor.name,
@@ -50,7 +57,11 @@ readdirSync(join("test", "input")).forEach(file => {
     } catch (error) {
       if (error.code === "ENOENT") {
         console.warn(`! generating ${outfile}`);
-        writeFileSync(outfile, JSON.stringify(actual, replacer, 2) + "\n", "utf8");
+        writeFileSync(
+          outfile,
+          JSON.stringify(actual, replacer, 2) + "\n",
+          "utf8"
+        );
         return;
       } else {
         throw error;

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -2,8 +2,19 @@ import {simple} from "acorn-walk";
 import tape from "tape-await";
 import {readdirSync, readFileSync, writeFileSync} from "fs";
 import {basename, extname, join} from "path";
-import {parseCell} from "../src/index.js";
+import {parseCell, peepId} from "../src/index.js";
 import walk from "../src/walk.js";
+
+tape('peepId', t => {
+  t.equal(peepId('a = 1'), 'a');
+  t.equal(peepId('viewof a = 1'), 'a');
+  t.equal(peepId('mutable a = 1'), 'a');
+  t.equal(peepId('class A {'), 'A');
+  t.equal(peepId('function a'), 'a');
+  t.equal(peepId('async function a'), 'a');
+  t.equal(peepId('function* a'), 'a');
+  t.equal(peepId('function /* yeah */ a'), 'a');
+});
 
 readdirSync(join("test", "input")).forEach(file => {
   if (extname(file) !== ".js") return;

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -5,7 +5,7 @@ import {basename, extname, join} from "path";
 import {parseCell, peepId} from "../src/index.js";
 import walk from "../src/walk.js";
 
-tape.only("peepId", t => {
+tape("peepId", t => {
   t.equal(peepId("a = 1"), "a");
   t.equal(peepId("viewof a = 1"), "a");
   t.equal(peepId("mutable a = 1"), "a");

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -9,6 +9,7 @@ tape("peepId", t => {
   t.equal(peepId("a = 1"), "a");
   t.equal(peepId("viewof a = 1"), "a");
   t.equal(peepId("mutable a = 1"), "a");
+  t.equal(peepId("mutable async = 1"), "async");
   t.equal(peepId("class A {"), "A");
   t.equal(peepId("class Z"), undefined);
   t.equal(peepId("class Z "), "Z");

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -1,28 +1,28 @@
-import {simple} from "acorn-walk";
+import { simple } from "acorn-walk";
 import tape from "tape-await";
-import {readdirSync, readFileSync, writeFileSync} from "fs";
-import {basename, extname, join} from "path";
-import {parseCell, peepId} from "../src/index.js";
+import { readdirSync, readFileSync, writeFileSync } from "fs";
+import { basename, extname, join } from "path";
+import { parseCell, peekId } from "../src/index.js";
 import walk from "../src/walk.js";
 
-tape("peepId", t => {
-  t.equal(peepId("a = 1"), "a");
-  t.equal(peepId("viewof a = 1"), "a");
-  t.equal(peepId("mutable a = 1"), "a");
-  t.equal(peepId("mutable async = 1"), "async");
-  t.equal(peepId("class A {"), "A");
-  t.equal(peepId("class Z"), undefined);
-  t.equal(peepId("class Z "), "Z");
-  t.equal(peepId("function a"), undefined);
-  t.equal(peepId("function a()"), "a");
-  t.equal(peepId("async function a()"), "a");
-  t.equal(peepId("function* a"), undefined);
-  t.equal(peepId("function /* yeah */ a()"), "a");
-  t.equal(peepId("function"), undefined);
-  t.equal(peepId("1"), undefined);
-  t.equal(peepId("({ a: 1 })"), undefined);
+tape("peekId", t => {
+  t.equal(peekId("a = 1"), "a");
+  t.equal(peekId("viewof a = 1"), "a");
+  t.equal(peekId("mutable a = 1"), "a");
+  t.equal(peekId("mutable async = 1"), "async");
+  t.equal(peekId("class A {"), "A");
+  t.equal(peekId("class Z"), undefined);
+  t.equal(peekId("class Z "), "Z");
+  t.equal(peekId("function a"), undefined);
+  t.equal(peekId("function a()"), "a");
+  t.equal(peekId("async function a()"), "a");
+  t.equal(peekId("function* a"), undefined);
+  t.equal(peekId("function /* yeah */ a()"), "a");
+  t.equal(peekId("function"), undefined);
+  t.equal(peekId("1"), undefined);
+  t.equal(peekId("({ a: 1 })"), undefined);
   t.equal(
-    peepId(`function queryAll(text, values) {
+    peekId(`function queryAll(text, values) {
   return fetch("https://api.observable.localh`),
     "queryAll"
   );
@@ -36,11 +36,13 @@ readdirSync(join("test", "input")).forEach(file => {
     let actual, expected;
 
     try {
-      actual = parseCell(readFileSync(infile, "utf8"), {globals: null});
+      actual = parseCell(readFileSync(infile, "utf8"), { globals: null });
     } catch (error) {
-      if (error instanceof ReferenceError
-          || error instanceof SyntaxError
-          || error instanceof TypeError) {
+      if (
+        error instanceof ReferenceError ||
+        error instanceof SyntaxError ||
+        error instanceof TypeError
+      ) {
         actual = {
           error: {
             type: error.constructor.name,
@@ -62,7 +64,11 @@ readdirSync(join("test", "input")).forEach(file => {
     } catch (error) {
       if (error.code === "ENOENT") {
         console.warn(`! generating ${outfile}`);
-        writeFileSync(outfile, JSON.stringify(actual, replacer, 2) + "\n", "utf8");
+        writeFileSync(
+          outfile,
+          JSON.stringify(actual, replacer, 2) + "\n",
+          "utf8"
+        );
         return;
       } else {
         throw error;


### PR DESCRIPTION
An API that tries to find determine the name of a truncated snippet of a cell. Unlike parseCell, this does not rely on the cell being fully parseable, because we're going to arbitrarily truncate the string.

- [x] Require a ( or { for function and class names, so we don't accidentally accept truncated names