### PR TITLE
Allow destructuring of cells.

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -178,7 +178,9 @@ export class CellParser extends Parser {
       // (But not an object expression or arrow function!)
       if (token.type === tt.parenL) {
         id = this.parseParenAndDistinguishExpression(true);
-        if (id.type === "ArrowFunctionExpression" || !this.eat(tt.eq)) {
+        if (id.type !== "ArrowFunctionExpression" && this.eat(tt.eq)) {
+          id = this.toAssignable(id, true);
+        } else {
           body = id;
           id = null;
         }

--- a/src/parse.js
+++ b/src/parse.js
@@ -163,6 +163,7 @@ export class CellParser extends Parser {
     this.O_function = 0;
     this.O_async = false;
     this.O_generator = false;
+    this.O_destructuring = null;
     this.strict = true;
     this.enterScope(SCOPE_FUNCTION | SCOPE_ASYNC | SCOPE_GENERATOR);
 
@@ -179,7 +180,7 @@ export class CellParser extends Parser {
       if (token.type === tt.parenL) {
         id = this.parseParenAndDistinguishExpression(true);
         if (id.type !== "ArrowFunctionExpression" && this.eat(tt.eq)) {
-          id = this.toAssignable(id, true);
+          id = this.toAssignable(id, true, this.O_destructuring);
         } else {
           body = id;
           id = null;
@@ -240,6 +241,10 @@ export class CellParser extends Parser {
     return node.type === "MutableExpression"
       ? node
       : super.toAssignable(node, isBinding, refDestructuringErrors);
+  }
+  checkExpressionErrors(refDestructuringErrors, andThrow) {
+    this.O_destructuring = refDestructuringErrors;
+    return super.checkExpressionErrors(refDestructuringErrors, andThrow);
   }
   checkUnreserved(node) {
     if (node.name === "viewof" || node.name === "mutable") {


### PR DESCRIPTION
Destructuring allows a cell to expose multiple values.

```js
({foo, bar}) = ({foo: 1, bar: 2})
```
```js
({foo, bar}) = { return {foo: 1, bar: 2}; }
```
```js
([foo, ...bar]) = [1, 2, 3]
```

This PR allows the cell.id to be an ObjectPattern or an ArrayPattern. There’s still a fair amount of work on the compiler side to turn this into the corresponding set of variables, but this serves as the language proposal.

Tests to come.