### PR TITLE
Disallow duplicate identifiers.

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -123,6 +123,7 @@ export class CellParser extends Parser {
   }
   parseImportSpecifiers() {
     const nodes = [];
+    const identifiers = new Set;
     let first = true;
     this.expect(tt.braceL);
     while (!this.eat(tt.braceR)) {
@@ -143,6 +144,10 @@ export class CellParser extends Parser {
         node.local = node.imported;
       }
       this.checkLVal(node.local, "let");
+      if (identifiers.has(node.local.name)) {
+        this.raise(node.local.start, `Identifier '${node.local.name}' has already been declared`);
+      }
+      identifiers.add(node.local.name);
       nodes.push(this.finishNode(node, "ImportSpecifier"));
     }
     return nodes;

--- a/tap-snapshots/test-parse-test.js-TAP.test.js
+++ b/tap-snapshots/test-parse-test.js-TAP.test.js
@@ -2258,6 +2258,20 @@ Object {
 }
 `
 
+exports[`test/parse-test.js TAP parse import-as-duplicate.js > must match snapshot 1`] = `
+Object {
+  "error": Object {
+    "loc": Object {
+      "column": 20,
+      "line": 1,
+    },
+    "message": "Identifier 'foo' has already been declared (1:20)",
+    "pos": 20,
+    "type": "SyntaxError",
+  },
+}
+`
+
 exports[`test/parse-test.js TAP parse import-default-as.js > must match snapshot 1`] = `
 Object {
   "error": Object {
@@ -2281,6 +2295,20 @@ Object {
     },
     "message": "Unexpected token (1:7)",
     "pos": 7,
+    "type": "SyntaxError",
+  },
+}
+`
+
+exports[`test/parse-test.js TAP parse import-duplicate.js > must match snapshot 1`] = `
+Object {
+  "error": Object {
+    "loc": Object {
+      "column": 13,
+      "line": 1,
+    },
+    "message": "Identifier 'foo' has already been declared (1:13)",
+    "pos": 13,
     "type": "SyntaxError",
   },
 }
@@ -2581,6 +2609,20 @@ Node {
 }
 `
 
+exports[`test/parse-test.js TAP parse import-with-as-duplicate.js > must match snapshot 1`] = `
+Object {
+  "error": Object {
+    "loc": Object {
+      "column": 28,
+      "line": 1,
+    },
+    "message": "Identifier 'foo' has already been declared (1:28)",
+    "pos": 28,
+    "type": "SyntaxError",
+  },
+}
+`
+
 exports[`test/parse-test.js TAP parse import-with-default-as.js > must match snapshot 1`] = `
 Object {
   "error": Object {
@@ -2604,6 +2646,20 @@ Object {
     },
     "message": "Unexpected keyword 'default' (1:19)",
     "pos": 19,
+    "type": "SyntaxError",
+  },
+}
+`
+
+exports[`test/parse-test.js TAP parse import-with-duplicate.js > must match snapshot 1`] = `
+Object {
+  "error": Object {
+    "loc": Object {
+      "column": 21,
+      "line": 1,
+    },
+    "message": "Identifier 'foo' has already been declared (1:21)",
+    "pos": 21,
     "type": "SyntaxError",
   },
 }

--- a/test/input/import-as-duplicate.js
+++ b/test/input/import-as-duplicate.js
@@ -1,0 +1,1 @@
+import {foo, bar as foo} from "module"

--- a/test/input/import-duplicate.js
+++ b/test/input/import-duplicate.js
@@ -1,0 +1,1 @@
+import {foo, foo} from "module"

--- a/test/input/import-with-as-duplicate.js
+++ b/test/input/import-with-as-duplicate.js
@@ -1,0 +1,1 @@
+import {} with {foo, bar as foo} from "module"

--- a/test/input/import-with-duplicate.js
+++ b/test/input/import-with-duplicate.js
@@ -1,0 +1,1 @@
+import {} with {foo, foo} from "module"


### PR DESCRIPTION
Disallows four forms of duplicate identifiers:

```js
import {foo, foo} from "module"
```
```js
import {foo, bar as foo} from "module"
```
```js
import {} with {foo, foo} from "module"
```
```js
import {} with {foo, bar as foo} from "module"
```
