### PR TITLE
Ignore masked references to FileAttachment.

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -1,7 +1,7 @@
 import {getLineInfo, tokTypes as tt, Parser} from "acorn";
 import defaultGlobals from "./globals.js";
 import findReferences from "./references.js";
-import findFileAttachments from "./file-attachments.js";
+import findFileAttachments from "./fileAttachments.js";
 
 const SCOPE_FUNCTION = 2;
 const SCOPE_ASYNC = 4;
@@ -13,7 +13,10 @@ const STATE_FUNCTION = Symbol("function");
 const STATE_NAME = Symbol("name");
 
 export function parseCell(input, {globals} = {}) {
-  return parseFileAttachments(parseReferences(CellParser.parse(input), input, globals));
+  const cell = CellParser.parse(input);
+  parseReferences(cell, input, globals);
+  parseFileAttachments(cell);
+  return cell;
 }
 
 /*

--- a/src/references.js
+++ b/src/references.js
@@ -1,4 +1,4 @@
-// Base on https://github.com/ForbesLindesay/acorn-globals
+// Based on https://github.com/ForbesLindesay/acorn-globals
 // Copyright (c) 2014 Forbes Lindesay
 // https://github.com/ForbesLindesay/acorn-globals/blob/master/LICENSE
 

--- a/tap-snapshots/test-parse-test.js-TAP.test.js
+++ b/tap-snapshots/test-parse-test.js-TAP.test.js
@@ -1202,7 +1202,7 @@ Object {
       "column": 4,
       "line": 1,
     },
-    "message": "FileAttachment() requires a single literal string as its argument. (1:4)",
+    "message": "FileAttachment() requires a single literal string argument. (1:4)",
     "pos": 4,
     "type": "SyntaxError",
   },
@@ -1216,10 +1216,122 @@ Object {
       "column": 4,
       "line": 1,
     },
-    "message": "FileAttachment() requires a single literal string as its argument. (1:4)",
+    "message": "FileAttachment() requires a single literal string argument. (1:4)",
     "pos": 4,
     "type": "SyntaxError",
   },
+}
+`
+
+exports[`test/parse-test.js TAP parse file-attachment-masked.js > must match snapshot 1`] = `
+Node {
+  "async": false,
+  "body": Node {
+    "body": Array [
+      Node {
+        "declarations": Array [
+          Node {
+            "end": 40,
+            "id": Node {
+              "end": 22,
+              "name": "FileAttachment",
+              "start": 8,
+              "type": "Identifier",
+            },
+            "init": Node {
+              "async": false,
+              "body": Node {
+                "end": 40,
+                "left": Node {
+                  "end": 36,
+                  "name": "a",
+                  "start": 35,
+                  "type": "Identifier",
+                },
+                "operator": "+",
+                "right": Node {
+                  "end": 40,
+                  "name": "b",
+                  "start": 39,
+                  "type": "Identifier",
+                },
+                "start": 35,
+                "type": "BinaryExpression",
+              },
+              "end": 40,
+              "expression": true,
+              "generator": false,
+              "id": null,
+              "params": Array [
+                Node {
+                  "end": 27,
+                  "name": "a",
+                  "start": 26,
+                  "type": "Identifier",
+                },
+                Node {
+                  "end": 30,
+                  "name": "b",
+                  "start": 29,
+                  "type": "Identifier",
+                },
+              ],
+              "start": 25,
+              "type": "ArrowFunctionExpression",
+            },
+            "start": 8,
+            "type": "VariableDeclarator",
+          },
+        ],
+        "end": 41,
+        "kind": "let",
+        "start": 4,
+        "type": "VariableDeclaration",
+      },
+      Node {
+        "argument": Node {
+          "arguments": Array [
+            Node {
+              "end": 67,
+              "raw": "1",
+              "start": 66,
+              "type": "Literal",
+              "value": 1,
+            },
+            Node {
+              "end": 70,
+              "raw": "2",
+              "start": 69,
+              "type": "Literal",
+              "value": 2,
+            },
+          ],
+          "callee": Node {
+            "end": 65,
+            "name": "FileAttachment",
+            "start": 51,
+            "type": "Identifier",
+          },
+          "end": 71,
+          "start": 51,
+          "type": "CallExpression",
+        },
+        "end": 72,
+        "start": 44,
+        "type": "ReturnStatement",
+      },
+    ],
+    "end": 74,
+    "start": 0,
+    "type": "BlockStatement",
+  },
+  "end": 75,
+  "fileAttachments": Map {},
+  "generator": false,
+  "id": null,
+  "references": Array [],
+  "start": 0,
+  "type": "Cell",
 }
 `
 

--- a/test/input/file-attachment-masked.js
+++ b/test/input/file-attachment-masked.js
@@ -1,0 +1,4 @@
+{
+  let FileAttachment = (a, b) => a + b;
+  return FileAttachment(1, 2);
+}


### PR DESCRIPTION
We currently consider all calls to FileAttachment to be file references, even if the FileAttachment symbol is masked in the current scope. I feel this is overzealous and inconsistent: if we don’t consider the reference to FileAttachment to be an external reference (i.e., a cell input), then we shouldn’t consider the call to be a file reference, either.

This does mean that you can circumvent the static enforcement of file references:

```js
(FileAttachment => FileAttachment("alphabet" + ".csv"))(FileAttachment)
```

But that’s already possible today:

```js
(f => f("alphabet" + ".csv"))(FileAttachment)
```

Deferring review request until Monday. 🤙 