### PR TITLE
recursive references

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -13,7 +13,10 @@ const STATE_FUNCTION = Symbol("function");
 const STATE_NAME = Symbol("name");
 
 export function parseCell(input, {globals} = {}) {
-  return parseFileAttachments(parseReferences(CellParser.parse(input), input, globals));
+  const cell = CellParser.parse(input);
+  parseReferences(cell, input, globals);
+  parseFileAttachments(cell);
+  return cell;
 }
 
 /*

--- a/test/bench.js
+++ b/test/bench.js
@@ -1,0 +1,32 @@
+import {performance} from "perf_hooks";
+import {parseCell} from "../src/index.js";
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    process.stdin
+        .on("error", reject)
+        .on("data", (chunk) => chunks.push(chunk))
+        .on("end", () => resolve(chunks.join("")))
+        .setEncoding("utf8");
+  });
+}
+
+readStdin().then((input) => {
+  const samples = [];
+
+  for (let i = 0; i < 40; ++i) {
+    const start = performance.now();
+    try {
+      parseCell(input);
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) {
+        throw error;
+      }
+    }
+    const end = performance.now();
+    samples.push(end - start);
+  }
+
+  console.log(samples.sort((a, b) => a - b)[samples.length >> 1]);
+});


### PR DESCRIPTION
This is a rewrite of acorn-globals that uses acorn-walk’s recursive rather than ancestor. It seems to be modestly faster, but not in a way that would be noticeable, even on 60+KB cells. Also, it doesn’t yet implement const assignment checking, and I’ve probably introduced some bugs. (Like for sure referencing a var before it is declared will now be considered an external reference; that’s fixable, but not trivial.)

I don’t think we want to submit this for the churn factor, but leaving it here in case we want to revisit this in the future for some reason.