### PR TITLE
Return empty ast for empty input even if tag is provided

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -14,7 +14,9 @@ const STATE_NAME = Symbol("name");
 
 export function parseCell(input, {tag, raw, globals, ...options} = {}) {
   let cell;
-  if (tag != null) {
+  // Parse empty input as JavaScript to keep ensure resulting ast
+  // is consistent for all empty input cases.
+  if (tag != null && input) {
     cell = TemplateCellParser.parse(input, options);
     cell.tag = tag;
     cell.raw = !!raw;

--- a/tap-snapshots/test-parse-test.js-TAP.test.js
+++ b/tap-snapshots/test-parse-test.js-TAP.test.js
@@ -1406,34 +1406,14 @@ Node {
 exports[`test/parse-test.js TAP parse empty.md > must match snapshot 1`] = `
 Node {
   "async": false,
-  "body": Node {
-    "end": 0,
-    "expressions": Array [],
-    "quasis": Array [
-      Node {
-        "end": 0,
-        "start": 0,
-        "tail": true,
-        "type": "TemplateElement",
-        "value": Object {
-          "cooked": "",
-          "raw": "",
-        },
-      },
-    ],
-    "start": 0,
-    "type": "TemplateLiteral",
-  },
+  "body": null,
   "databaseClients": Map {},
   "end": 0,
   "fileAttachments": Map {},
   "generator": false,
   "id": null,
-  "raw": false,
-  "references": Array [],
   "secrets": Map {},
   "start": 0,
-  "tag": "md",
   "type": "Cell",
 }
 `


### PR DESCRIPTION
The only thing I can think of where this might go wrong is if there is a tag that will return something useful even in the empty state, but I doubt that will ever be the case? https://github.com/observablehq/observablehq/issues/2943