### PR TITLE
Add "nodeName" to protected globals

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -44,6 +44,7 @@ export default new Set([
   "Map",
   "Math",
   "NaN",
+  "nodeName",
   "Number",
   "navigator",
   "Object",


### PR DESCRIPTION
Slack discussion: https://observablehq.slack.com/archives/C014ABGPNU9/p1677648470994169

[React will throw](https://github.com/facebook/react/pull/10076) if any DOM element gets an ID of `"nodeName"`. We automatically assign any cell an ID with its name, which creates the potential for client errors if a `nodeName` cell is created.

<img width="1512" alt="Screen Shot 2023-03-01 at 9 48 01 AM" src="https://user-images.githubusercontent.com/1418487/222178240-8b8d6f97-0184-4433-b572-f5a96b2abc2d.png">